### PR TITLE
Added required file check

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -42,7 +42,7 @@ def checkForUpdates():
             sys.exit(1)
     else:
         print "The required file update-this-repo.sh was not found. This is likely to occur if you manually copied updater.py here.\n"+ \
-            "Please run this from the original location you installed (usually <brewpi-script>/utils) and try again."
+            "Please run this from the original location you installed the brewpi-tools git repo and try again."
         sys.exit(1)
 
 


### PR DESCRIPTION
Current exception will catch update-this-repo.sh not existing as a ProcessError, and display the error "script not up to date, please re-run updater.py", assuming the only error that this would catch is an update error. If the user moves this file outside of the utils dir for some reason, or copies it into the brewpi-script dir from an external brewpi-tools repo (and not the other required files), this error would be misleading. This patch checks to see if required file exist in same dir and suggest a solution.
