### PR TITLE
removed PHP 5 dependencies and added php7.0-mbstring dependancy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,8 +47,7 @@ warn() {
 die () {
   local st="$?"
   warn "$@"
-  exit "$st"
-}
+  exit "$st"}
 
 ############
 ### Create install log file
@@ -92,7 +91,7 @@ if [ $(($nowTime - $lastUpdate)) -gt 604800 ] ; then
     echo "last apt-get update was over a week ago. Running apt-get update before updating dependencies"
     sudo apt-get update||die
 fi
-sudo apt-get install -y apache2 libapache2-mod-php5 php5-cli php5-common php5-cgi php5 git-core build-essential python-dev python-pip pastebinit || die
+sudo apt-get install -y apache2 libapache2-mod-php php-cli php-common php-cgi php git-core build-essential python-dev python-pip pastebinit || die
 echo -e "\n***** Installing/updating required python packages via pip... *****\n"
 sudo pip install pyserial psutil simplejson configobj gitpython --upgrade
 echo -e "\n***** Done processing BrewPi dependencies *****\n"

--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,7 @@ if [ $(($nowTime - $lastUpdate)) -gt 604800 ] ; then
     echo "last apt-get update was over a week ago. Running apt-get update before updating dependencies"
     sudo apt-get update||die
 fi
-sudo apt-get install -y apache2 libapache2-mod-php php-cli php-common php-cgi php git-core build-essential python-dev python-pip pastebinit php7.0-mbstring || die
+sudo apt-get install -y apache2 libapache2-mod-php php-cli php-common php-cgi php git-core build-essential python-dev python-pip pastebinit php7.0-mbstring python-configobj || die
 echo -e "\n***** Installing/updating required python packages via pip... *****\n"
 sudo pip install pyserial psutil simplejson configobj gitpython --upgrade
 echo -e "\n***** Done processing BrewPi dependencies *****\n"

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ exec 2>&1
 
 ############
 ### Check for network connection
-###########
+ ###########
 echo -e "\nChecking for Internet connection..."
 ping -c 3 github.com &> /dev/null
 if [ $? -ne 0 ]; then
@@ -91,7 +91,7 @@ if [ $(($nowTime - $lastUpdate)) -gt 604800 ] ; then
     echo "last apt-get update was over a week ago. Running apt-get update before updating dependencies"
     sudo apt-get update||die
 fi
-sudo apt-get install -y apache2 libapache2-mod-php php-cli php-common php-cgi php git-core build-essential python-dev python-pip pastebinit || die
+sudo apt-get install -y apache2 libapache2-mod-php php-cli php-common php-cgi php git-core build-essential python-dev python-pip pastebinit php7.0-mbstring || die
 echo -e "\n***** Installing/updating required python packages via pip... *****\n"
 sudo pip install pyserial psutil simplejson configobj gitpython --upgrade
 echo -e "\n***** Done processing BrewPi dependencies *****\n"

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,8 @@ warn() {
 die () {
   local st="$?"
   warn "$@"
-  exit "$st"}
+  exit "$st"
+}
 
 ############
 ### Create install log file
@@ -57,7 +58,7 @@ exec 2>&1
 
 ############
 ### Check for network connection
- ###########
+###########
 echo -e "\nChecking for Internet connection..."
 ping -c 3 github.com &> /dev/null
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Removed the php 5.0 dependencies from the install.sh script.  I also added the `php7.0-mbstring` dependency that was being called by the `index.php`.  The missing dependency would cause a `500` error and throw and error in the `/var/log/apache2/error.log`
```
PHP Fatal error:  Uncaught Error: Call to undefined function mb_convert_encoding() in /var/www/html/index.php:53\nStack trace:\n#0 /var/www/html/index.php(24): prepareJSON('{"beerName": "S...')\n#1 {main}\n  thrown in /var/www/html/index.php on line 53
```
This can all be found in issue #39.